### PR TITLE
WIP: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM gentoo/portage:latest as portage
+
+FROM gentoo/stage3-amd64:latest
+
+COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
+
+WORKDIR /usr/src/quickstart
+COPY . /usr/src/quickstart
+
+RUN /bin/sh ./util/provision.sh && \
+    make install
+

--- a/util/provision.sh
+++ b/util/provision.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+# Set keywords
+cat << EOF > /etc/portage/package.accept_keywords
+app-admin/haskell-updater ~amd64
+app-text/pandoc ~amd64
+dev-haskell/* ~amd64
+dev-lang/ghc ~amd64
+dev-util/shellcheck ~amd64
+EOF
+
+# Fix slot conflicts
+#emerge --oneshot =dev-python/setuptools-44.1.0
+#emerge --oneshot =dev-python/certifi-2020.4.5.1
+
+# Create dependency set
+mkdir -p /etc/portage/sets
+
+cat << EOF > /etc/portage/sets/quickstart-dependencies
+# development dependencies for quickstart
+app-text/pandoc
+dev-util/shellcheck
+EOF
+
+# Install dependencies
+emerge -ng --backtrack=30 @quickstart-dependencies
+
+# Set vi as default editor
+ln -s /bin/busybox /usr/local/bin/vi
+eselect editor set /usr/local/bin/vi
+


### PR DESCRIPTION
```sh
WARNING: One or more updates/rebuilds have been skipped due to a dependency conflict:

dev-python/setuptools:0

  (dev-python/setuptools-44.1.0:0/0::gentoo, ebuild scheduled for merge) conflicts with
    >=dev-python/setuptools-42.0.2[python_targets_python3_6(-),-python_single_target_pypy3(-),-python_single_target_python3_6(-),-python_single_target_python3_7(-),-python_single_target_python3_8(-)] required by (app-portage/gemato-14.3:0/0::gentoo, installed)
                                                                                                                                                                                                       


!!! The following update(s) have been skipped due to unsatisfied dependencies
!!! triggered by backtracking:

dev-haskell/cmark:0

!!! The following installed packages are masked:
- sys-libs/glibc-2.29-r7::gentoo (masked by: package.mask)
/var/db/repos/gentoo/profiles/package.mask:
# Michał Górny <mgorny@gentoo.org>, Andreas K. Hüttel <dilfridge@gentoo.org>,
# Matthias Maier <tamiko@gentoo.org> (2017-05-21 and later updates)
# These old versions of toolchain packages (binutils, gcc, glibc) are no
# longer officially supported and are not suitable for general use. Using
# these packages can result in build failures (and possible breakage) for
# many packages, and may leave your system vulnerable to known security
# exploits.
# If you still use one of these old toolchain packages, please upgrade (and
# switch the compiler / the binutils) ASAP. If you need them for a specific
# (isolated) use case, feel free to unmask them on your system.

For more information, see the MASKED PACKAGES section in the emerge
man page or refer to the Gentoo Handbook.

```

See: https://wiki.gentoo.org/wiki/Troubleshooting#Portage_issues